### PR TITLE
Add ability for buttons to have custom icons preceeding text

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,11 +24,12 @@ modal([options])[.on('event')]
 - buttons (array)
   - text (string) the button text
   - event (string) the event name to fire when the button is clicked
-  - classname (string) the classname to apply to the button
+  - className (string) the className to apply to the button
   - iconClassName (string) adds an `i` element before button text with the given class(es)
-  - keyCode (number) the keycode of a shortcut key for the button
-  - clickOutsideToClose (boolean) whether a click event outside of the modal should close it
-  - clickOutsideEvent (string) the name of the event to be triggered on clicks outside of the modal
+  - keyCodes ([numbers]) the keycodes of shortcuts keys for the button
+- clickOutsideToClose (boolean) whether a click event outside of the modal should close it
+- clickOutsideEvent (string) the name of the event to be triggered on clicks outside of the modal
+- className (string) optional class to apply to the modal element
 
 Events will be fired on the modal according to which button is clicked.
 Defaults are confirm/cancel, but these can be overriden in your options.
@@ -40,8 +41,8 @@ modal(
   { title: 'Delete object'
   , content: 'Are you sure you want to delete this object?'
   , buttons:
-    [ { text: 'Don\'t delete', event: 'cancel', classname: '' }
-    , { text: 'Delete', event: 'confirm', classname: 'danger', iconClassName: 'icon-delete'}
+    [ { text: 'Don’t delete', event: 'cancel', keyCodes: [ 27 ] }
+    , { text: 'Delete', event: 'confirm', className: 'button-danger', iconClassName: 'icon-delete'}
     ]
   })
   .on('confirm', deleteItem)

--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ modal(
   , content: 'Are you sure you want to delete this object?'
   , buttons:
     [ { text: 'Don’t delete', event: 'cancel', keyCodes: [ 27 ] }
-    , { text: 'Delete', event: 'confirm', className: 'button-danger', iconClassName: 'icon-delete'}
+    , { text: 'Delete', event: 'confirm', className: 'button-danger', iconClassName: 'icon-delete' }
     ]
   })
   .on('confirm', deleteItem)

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,7 @@ modal([options])[.on('event')]
   - text (string) the button text
   - event (string) the event name to fire when the button is clicked
   - classname (string) the classname to apply to the button
+  - iconClassName (string) adds an `i` element before button text with the given class(es)
   - keyCode (number) the keycode of a shortcut key for the button
   - clickOutsideToClose (boolean) whether a click event outside of the modal should close it
   - clickOutsideEvent (string) the name of the event to be triggered on clicks outside of the modal
@@ -40,7 +41,7 @@ modal(
   , content: 'Are you sure you want to delete this object?'
   , buttons:
     [ { text: 'Don\'t delete', event: 'cancel', classname: '' }
-    , { text: 'Delete', event: 'confirm', classname: 'danger' }
+    , { text: 'Delete', event: 'confirm', classname: 'danger', iconClassName: 'icon-delete'}
     ]
   })
   .on('confirm', deleteItem)

--- a/modal-template.jade
+++ b/modal-template.jade
@@ -6,4 +6,8 @@
     if (buttons.length)
       .modal-controls
         each button in buttons
-          button.js-button(class=button.className) #{button.text}
+          button.js-button(class=button.className)
+            if button.iconClassName
+              i(class=button.iconClassName)
+              |  
+            | #{button.text}

--- a/modal-template.js
+++ b/modal-template.js
@@ -21,7 +21,14 @@ buf.push('<div class="modal-controls">');
 
 buf.push('<button');
 buf.push(attrs({ "class": ('js-button') + ' ' + (button.className) }, {"class":true}));
-buf.push('>' + escape((interp = button.text) == null ? '' : interp) + '</button>');
+buf.push('>');
+if ( button.iconClassName)
+{
+buf.push('<i');
+buf.push(attrs({ "class": (button.iconClassName) }, {"class":true}));
+buf.push('></i> ');
+}
+buf.push('' + escape((interp = button.text) == null ? '' : interp) + '</button>');
     }
 
   } else {
@@ -31,7 +38,14 @@ buf.push('>' + escape((interp = button.text) == null ? '' : interp) + '</button>
 
 buf.push('<button');
 buf.push(attrs({ "class": ('js-button') + ' ' + (button.className) }, {"class":true}));
-buf.push('>' + escape((interp = button.text) == null ? '' : interp) + '</button>');
+buf.push('>');
+if ( button.iconClassName)
+{
+buf.push('<i');
+buf.push(attrs({ "class": (button.iconClassName) }, {"class":true}));
+buf.push('></i> ');
+}
+buf.push('' + escape((interp = button.text) == null ? '' : interp) + '</button>');
     }
 
   }

--- a/modal.js
+++ b/modal.js
@@ -32,7 +32,7 @@ module.exports = modal
  *     , content: 'Are you sure you want to delete this object?'
  *     , buttons:
  *       [ { text: 'Don’t delete', event: 'cancel' }
- *       , { text: 'Delete', event: 'confirm', className: 'button-danger', iconClassName: 'icon-delete'}
+ *       , { text: 'Delete', event: 'confirm', className: 'button-danger', iconClassName: 'icon-delete' }
  *       ]
  *     })
  *     .on('confirm', deleteItem)

--- a/modal.js
+++ b/modal.js
@@ -16,6 +16,7 @@ module.exports = modal
  *       - text (string) the button text
  *       - event (string) the event name to fire when the button is clicked
  *       - className (string) the className to apply to the button
+ *       - iconClassName (string) adds an `i` element before button text with the given class(es)
  *       - keyCodes ([numbers]) the keycodes of shortcuts key for the button
  *       - clickOutsideToClose (boolean) whether a click event outside of the modal should close it
  *       - clickOutsideEvent (string) the name of the event to be triggered on clicks outside of the modal
@@ -30,7 +31,7 @@ module.exports = modal
  *     , content: 'Are you sure you want to delete this object?'
  *     , buttons:
  *       [ { text: 'Don\'t delete', event: 'cancel', className: '' }
- *       , { text: 'Delete', event: 'confirm', className: 'danger' }
+ *       , { text: 'Delete', event: 'confirm', classname: 'danger', iconClassName: 'icon-delete'}
  *       ]
  *     })
  *     .on('confirm', deleteItem)
@@ -43,8 +44,8 @@ var Emitter = require('events').EventEmitter
     { title: 'Are you sure?'
     , content: 'Please confirm this action.'
     , buttons:
-      [ { text: 'Cancel', event: 'cancel', className: '', keyCodes: [ 27 ] }
-      , { text: 'Confirm', event: 'confirm', className: '' }
+      [ { text: 'Cancel', event: 'cancel', className: '', iconClassName: '', keyCodes: [ 27 ] }
+      , { text: 'Confirm', event: 'confirm', className: '', iconClassName: '' }
       ]
     , clickOutsideToClose: true
     , clickOutsideEvent: 'cancel'

--- a/modal.js
+++ b/modal.js
@@ -17,9 +17,10 @@ module.exports = modal
  *       - event (string) the event name to fire when the button is clicked
  *       - className (string) the className to apply to the button
  *       - iconClassName (string) adds an `i` element before button text with the given class(es)
- *       - keyCodes ([numbers]) the keycodes of shortcuts key for the button
- *       - clickOutsideToClose (boolean) whether a click event outside of the modal should close it
- *       - clickOutsideEvent (string) the name of the event to be triggered on clicks outside of the modal
+ *       - keyCodes ([numbers]) the keycodes of shortcut keys for the button
+ *     - clickOutsideToClose (boolean) whether a click event outside of the modal should close it
+ *     - clickOutsideEvent (string) the name of the event to be triggered on clicks outside of the modal
+ *     - className (string) optional class to apply to the modal element
  *
  *  Events will be fired on the modal according to which button is clicked.
  *  Defaults are confirm/cancel, but these can be overriden in your options.
@@ -30,8 +31,8 @@ module.exports = modal
  *     { title: 'Delete object'
  *     , content: 'Are you sure you want to delete this object?'
  *     , buttons:
- *       [ { text: 'Don\'t delete', event: 'cancel', className: '' }
- *       , { text: 'Delete', event: 'confirm', classname: 'danger', iconClassName: 'icon-delete'}
+ *       [ { text: 'Don’t delete', event: 'cancel' }
+ *       , { text: 'Delete', event: 'confirm', className: 'button-danger', iconClassName: 'icon-delete'}
  *       ]
  *     })
  *     .on('confirm', deleteItem)

--- a/test/modal.test.js
+++ b/test/modal.test.js
@@ -90,7 +90,7 @@ describe('modal', function () {
         })
       })
 
-      it('should add the correct classes', function () {
+      it('should add the correct button classes', function () {
         var buttons =
           [ { text: 'Button 1', className: 'one-class' }
           , { text: 'Button 2', className: 'multiple classes' }
@@ -99,6 +99,26 @@ describe('modal', function () {
         assert($('.js-button').eq(0).hasClass('one-class'))
         assert($('.js-button').eq(1).hasClass('multiple'))
         assert($('.js-button').eq(1).hasClass('classes'))
+      })
+
+      it ('should have no button icon by default', function (done) {
+        modal({ fx: false })
+        assert.equal($('.modal-overlay').length, 1)
+        setTimeout(function () {
+          assert.equal($('i').length, 0)
+          done()
+        }, 0)
+      })
+
+      it ('should add button icons with the correct classes', function () {
+        var buttons =
+          [ { text: 'Button 1', iconClassName: 'one-class' }
+          , { text: 'Button 2', iconClassName: 'multiple classes' }
+          ]
+        modal({ fx: false, buttons: buttons })
+        assert($('i').eq(0).hasClass('one-class'))
+        assert($('i').eq(1).hasClass('multiple'))
+        assert($('i').eq(1).hasClass('classes'))
       })
 
     })


### PR DESCRIPTION
## Description

Allows for icons in buttons to provide extra visual triggers and to denote importance.
## Solution

A new `iconClassName` option for each button which, if present, adds an `<i>` element with the supplied class(es) before the text, immediately followed by a space character to avoid icons and text touching.

Example:
![screen shot 2015-04-10 at 09 57 34](https://cloud.githubusercontent.com/assets/720908/7084748/40cfcd76-df68-11e4-8d11-f914b6287b46.png)

It can handle multiple classes, and has passing tests in the same style as existing ones.

There are no breaking changes in this work (feel free to check :P).

---

Also tidied the documentation a little whilst adding my stuff. Some inconsistencies and incorrect indentation are now fixed.
